### PR TITLE
Default values for answers

### DIFF
--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -14,6 +14,7 @@ class Answer < ActiveRecord::Base
       hsh.merge!(text_field_type: text_field_type) if text_field_type
       hsh.merge!(mask: mask) if mask
       value = user_facts[name]
+      hsh.merge!(value: default_value) if default_value
       hsh.merge!(value: value) if value
       hsh
     end

--- a/db/migrate/20171022173300_add_default_value_to_answers.rb
+++ b/db/migrate/20171022173300_add_default_value_to_answers.rb
@@ -1,0 +1,5 @@
+class AddDefaultValueToAnswers < ActiveRecord::Migration[5.1]
+  def change
+    add_column :answers, :default_value, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171020135253) do
+ActiveRecord::Schema.define(version: 20171022173300) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -24,6 +24,7 @@ ActiveRecord::Schema.define(version: 20171020135253) do
     t.string "text_field_type"
     t.string "mask"
     t.integer "workflow_id"
+    t.text "default_value"
     t.index ["workflow_id", "name"], name: "index_answers_on_workflow_id_and_name", unique: true
   end
 

--- a/features/api/answers.feature
+++ b/features/api/answers.feature
@@ -1,0 +1,44 @@
+Feature: Answers
+
+  Scenario: Answer with numbers in name
+    Given I am Alpha Numeric
+    When I send a POST request to "/api/workflows/alphanumeric/steps" with the following:
+    """
+    {
+      "facts": {}
+    }
+    """
+    Then the response status should be "200"
+    And the JSON response should be:
+    """
+    {
+      "token": "alphanumeric",
+      "text": "Letter.{{?alpha_1}}",
+      "parts": [
+        { "type": "text", "content": "Letter." },
+        { "type": "hidden", "name": "alpha_1" }
+      ]
+    }
+    """
+
+  Scenario: Answers with default_value set should return them
+    Given I am Default Value
+    When I send a POST request to "/api/workflows/defaultvalue/steps" with the following:
+    """
+    {
+      "facts": {}
+    }
+    """
+    Then the response status should be "200"
+    And the JSON response should be:
+    """
+    {
+      "token": "defaultvalue",
+      "text": "Default.{{?default_value}}",
+      "parts": [
+        { "type": "text", "content": "Default." },
+        { "type": "hidden", "name": "default_value", "value": "true" }
+      ]
+    }
+    """
+

--- a/features/support/personas.rb
+++ b/features/support/personas.rb
@@ -87,6 +87,19 @@ Cucumber::Persona.define "Alpha Numeric" do
                 workflow: wf)
 end
 
+Cucumber::Persona.define "Default Value" do
+  wf = Workflow.find_or_create_by(token: 'defaultvalue')
+  Step.create!(token: "defaultvalue",
+               workflow: wf,
+               text: "Default.{{?default_value}}",
+               conditions: "default_value=")
+  Answer.create(name: 'default_value',
+                input_type: 'hidden',
+                default_value: 'true',
+                workflow: wf)
+end
+
+
 Cucumber::Persona.define "Arthur Dent" do
   wf = Workflow.find_or_create_by(token: 'auth')
 


### PR DESCRIPTION
# Changelog

* Adding default values to answers - useful when hidden answers serve as a progress check