### PR TITLE
Default values are settable within step text

### DIFF
--- a/features/api/answers.feature
+++ b/features/api/answers.feature
@@ -21,6 +21,28 @@ Feature: Answers
     }
     """
 
+  Scenario: Answers with default_value set in the step text should return that value
+    Given I am Default Textvalue
+    When I send a POST request to "/api/workflows/defaulttextvalue/steps" with the following:
+    """
+    {
+    "facts": {}
+    }
+    """
+    Then the response status should be "200"
+    And the JSON response should be:
+    """
+    {
+      "token": "defaulttextvalue",
+      "text": "Default.{{?default_text_value='false'}}",
+      "parts": [
+        { "type": "text", "content": "Default." },
+        { "type": "hidden", "name": "default_text_value", "value": "false" }
+      ]
+    }
+    """
+
+
   Scenario: Answers with default_value set should return them
     Given I am Default Value
     When I send a POST request to "/api/workflows/defaultvalue/steps" with the following:

--- a/features/support/personas.rb
+++ b/features/support/personas.rb
@@ -99,6 +99,16 @@ Cucumber::Persona.define "Default Value" do
                 workflow: wf)
 end
 
+Cucumber::Persona.define "Default Textvalue" do
+  wf = Workflow.find_or_create_by(token: 'defaulttextvalue')
+  Step.create!(token: "defaulttextvalue",
+               workflow: wf,
+               text: "Default.{{?default_text_value='false'}}",
+               conditions: "default_text_value=")
+  Answer.create(name: 'default_text_value',
+                input_type: 'hidden',
+                workflow: wf)
+end
 
 Cucumber::Persona.define "Arthur Dent" do
   wf = Workflow.find_or_create_by(token: 'auth')


### PR DESCRIPTION
# Changelog

* Default values can now be set within step text, so that the same answer can have different default values across steps.