### PR TITLE
Splitting json text

### DIFF
--- a/features/api/workflows/callout.feature
+++ b/features/api/workflows/callout.feature
@@ -49,7 +49,7 @@ Feature: Callouts
         { "type": "text", "content": "got" },
         { "type": "text", "content": "it!" },
         { "type": "text", "content": "Secret:" },
-        { "type": "text", "content": 123 }
+        { "type": "text", "content": "123" }
       ]
     }
     """
@@ -91,11 +91,33 @@ Feature: Callouts
     """
     {
       "token": "present",
-      "text": "And accounted for!",
+      "text": "Present! {{$..present}}",
       "parts": [
+        { "type": "text", "content": "Present!" },
         { "type": "text", "content": "And" },
         { "type": "text", "content": "accounted" },
         { "type": "text", "content": "for!" }
+      ]
+    }
+    """
+
+  Scenario: Steps with unsuccessful callout response testing presence of boolean
+    When I send a POST request to "/api/workflows/callout/prompts" with the following:
+    """
+    {
+    "facts": { "present": "false"}
+    }
+    """
+    Then the response status should be "201"
+    And the JSON response should be:
+    """
+    {
+      "token": "present",
+      "text": "Not present",
+      "cta": "Oh well",
+      "parts": [
+        { "type": "text", "content": "Not" },
+        { "type": "text", "content": "present" }
       ]
     }
     """

--- a/features/support/personas.rb
+++ b/features/support/personas.rb
@@ -66,16 +66,20 @@ Cucumber::Persona.define "Call Out" do
     .to_return(status: 404, body: '{"error": "It was something else."}', headers: { 'Content-Type' => "application/json" })
 
   wf.steps.create!(token: "present",
-                   text: "And accounted for!",
-                   callout: "http://www.callout.com/present",
+                   text: "Present! {{$..present}}",
+                   callout: "http://www.callout.com/present?present={{present}}",
                    callout_method: "get",
-                   conditions: 'present=true',
-                   callout_success: "$..present[?(@['value'])]",
+                   conditions: 'present!=',
+                   callout_success: "$..present[?(@['present'])]",
                    callout_failure_text: "Not present",
+                   callout_failure_cta: "Oh well"
                   )
 
-  stub_request(:get, /http:\/\/www.callout.com\/present/)
-    .to_return(status: 200, body: '{"present": true}', headers: { 'Content-Type' => "application/json" })
+  stub_request(:get, /http:\/\/www.callout.com\/present\?present=true/)
+    .to_return(status: 200, body: '{"present": "And accounted for!"}', headers: { 'Content-Type' => "application/json" })
+
+  stub_request(:get, /http:\/\/www.callout.com\/present\?present=false/)
+    .to_return(status: 200, body: '{"notpresent": "true"}', headers: { 'Content-Type' => "application/json" })
 end
 
 Cucumber::Persona.define "New Line" do

--- a/lib/prompt/parts_collection.rb
+++ b/lib/prompt/parts_collection.rb
@@ -41,7 +41,7 @@ class PartsCollection
       else
         new_text(item)
       end
-    end
+    end.flatten
   end
 
   def new_question(item)
@@ -79,7 +79,10 @@ class PartsCollection
 
   def new_json(item)
     path = JsonPath.new('$'+item)
-    { type: "text", content: path.on(facts.to_json).first }
+    content = path.on(facts.to_json).first
+    content.to_s.split(" ").map do |c|
+      new_text(c)
+    end
   end
 
   def new_newline


### PR DESCRIPTION
# Changelog

* Content returned by JSON could be long, and could become disconnected from rest of the content if it was longer than 1 line. Splitting by word now so that it is indistinguishable from rest of text.